### PR TITLE
适配 "Server 酱" App

### DIFF
--- a/APP/NotifyIconsSupportConfig.json
+++ b/APP/NotifyIconsSupportConfig.json
@@ -5954,5 +5954,14 @@
     "contributorName": "ningge", 
     "isEnabled": true, 
     "isEnabledAll": false 
+  },
+  {
+    "appName": "Server 酱",
+    "packageName": "com.ft07.serverchan.app3.server_app3",
+    "iconBitmap": "iVBORw0KGgoAAAANSUhEUgAAAEgAAABIBAMAAACnw650AAAAMFBMVEUAAAD///////////////////////////////////////////////////////////87TQQwAAAAEHRSTlMAIJ/v/zBggI/fcECvEM9Qr/fzAwAAAURJREFUeNrdlDFKw3AchZ9C20FFh4IHsCcQO7rY1ypWtKCbS4ceIILg6tDNVW/gARwUhODWAwiOglMO4BHEl4Tyx+T/JsH6bfnx8b4sCf4oS1usZXuEnAkj7EM0GSWR1GaUvqQpo+xJumWUniQaSukwreGec2mIGh7/j9S4g5dOeyMrNXbYtdIq2Rs5aS0ju07Ch6aMpCkjFVNO0pSRiiknacpJ6JAnr0ZaJjl2S5fkAEZqashIk+8hI2nISMXQe5rzUilpSHcxrJMGiEvKjb3UHMBL2ACAzauci9/+OBdQmnMEALPgVPEf/wTWK/7jneC2C7z93EY7vIW18n1bDHthjdcQ07AX1g6QszILeuHTA0rO05xnFtwUhydUkFEcI8YZRR8xWhQJomS+pp5qvpfAkKnmeqr5XgJLpprr9eFpJVgEvgDvQTvRHNyd0QAAAABJRU5ErkJggg==",
+    "iconColor": "#ff00598c",
+    "contributorName": "PianCat",
+    "isEnabled": true,
+    "isEnabledAll": false
   }
 ]


### PR DESCRIPTION
添加应用
Server 酱
`com.ft07.serverchan.app3.server_app3`
关联 Pr #538 
已经尝试联系过开发者，经过一年的更新和等待后开发者仍未添加相应功能，故此再一次开启Pr


![Screenshot_2025-01-07-02-49-12-87_1584f1d8cc4c3efa14862223b41fd22e](https://github.com/user-attachments/assets/c6fdd211-98eb-4edc-8a63-9db683130e5f)
